### PR TITLE
Added code for plugins and an example plugin logging URI being added

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,8 @@ init.d/Makefile
 m4/Makefile
 docs/Makefile
 docbook-html5/Makefile
+crawler/plug-ins/Makefile
+crawler/plug-ins/logger/Makefile
 ])
 
 AC_CONFIG_FILES([init.d/crawler:init.d/crawler.sh.in],[chmod +x init.d/crawler])

--- a/crawler/Makefile.am
+++ b/crawler/Makefile.am
@@ -17,7 +17,7 @@
 ##  limitations under the License.
 ##
 
-SUBDIRS = queues processors .
+SUBDIRS = queues processors plug-ins .
 
 dist_doc_DATA = crawl.conf
 

--- a/crawler/add.c
+++ b/crawler/add.c
@@ -128,10 +128,14 @@ main(int argc, char **argv)
 			if(force)
 			{
 				r = queue->api->force_add(queue, uri, uribuf);
+				// Send a signal to all the plugins watching on this event
+				crawl_plugin_signal(crawler, QUEUE_URI_ADDED, uristr);
 			}
 			else
 			{
 				r = queue->api->add(queue, uri, uribuf);
+				// Send a signal to all the plugins watching on this event
+				crawl_plugin_signal(crawler, QUEUE_URI_ADDED, uristr);
 			}
 			if(r)
 			{
@@ -159,10 +163,14 @@ main(int argc, char **argv)
 		if(force)
 		{
 			r = queue->api->force_add(queue, uri, uristr);
+			// Send a signal to all the plugins watching on this event
+			crawl_plugin_signal(crawler, QUEUE_URI_ADDED, uristr);
 		}
 		else
 		{
 			r = queue->api->add(queue, uri, uristr);
+			// Send a signal to all the plugins watching on this event
+			crawl_plugin_signal(crawler, QUEUE_URI_ADDED, uristr);
 		}
 		if(r)
 		{

--- a/crawler/context.c
+++ b/crawler/context.c
@@ -93,6 +93,7 @@ context_create(int crawler_offset)
 	p->crawler_id = p->thread_offset + p->thread_base;
 	p->cache_id = p->crawler_id;
 	p->crawl = crawl;
+
 	crawl_set_logger(p->crawl, log_vprintf);
 	crawl_set_userdata(p->crawl, p);
 	crawl_set_verbose(p->crawl, config_get_bool("crawler:verbose", 0));

--- a/crawler/p_libcrawld.h
+++ b/crawler/p_libcrawld.h
@@ -40,6 +40,9 @@
 # include "libsupport.h"
 # include "liburi.h"
 
+typedef int (*crawl_plugin_init_fn)(void);
+typedef int (*crawl_plugin_cleanup_fn)(void);
+
 struct context_struct
 {
 	struct context_api_struct *api;
@@ -59,6 +62,7 @@ struct context_struct
 	int terminate;
 	int oneshot;
 };
+
 
 CRAWLSTATE policy_uri_(CRAWL *crawl, URI *uri, const char *uristr, void *userdata);
 

--- a/crawler/plug-ins/Makefile.am
+++ b/crawler/plug-ins/Makefile.am
@@ -1,0 +1,19 @@
+## Twine: A Linked Data workflow engine
+##
+## Author: Mo McRoberts <mo.mcroberts@bbc.co.uk>
+##
+## Copyright (c) 2014-2016 BBC
+##
+##  Licensed under the Apache License, Version 2.0 (the "License");
+##  you may not use this file except in compliance with the License.
+##  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+##  Unless required by applicable law or agreed to in writing, software
+##  distributed under the License is distributed on an "AS IS" BASIS,
+##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##  See the License for the specific language governing permissions and
+##  limitations under the License.
+
+SUBDIRS = logger

--- a/crawler/plug-ins/logger/Makefile.am
+++ b/crawler/plug-ins/logger/Makefile.am
@@ -1,6 +1,6 @@
 ## Author: Mo McRoberts <mo.mcroberts@bbc.co.uk>
 ##
-## Copyright 2014-2015 BBC
+## Copyright 2016 BBC
 
 ## Copyright 2013 Mo McRoberts.
 ##
@@ -17,26 +17,15 @@
 ##  limitations under the License.
 ##
 
-SUBDIRS = caches .
-
-EXTRA_DIST = README.md
-
-lib_LTLIBRARIES = libcrawl.la
-
-include_HEADERS = libcrawl.h
-
 AM_CPPFLAGS = @AM_CPPFLAGS@ \
-	-I$(top_builddir)/libsupport -I$(top_srcdir)/libsupport
+		-I$(top_builddir)/libcrawl -I$(top_srcdir)/libcrawl \
+		-I$(top_builddir)/libsupport -I$(top_srcdir)/libsupport 
 
-libcrawl_la_SOURCES = p_libcrawl.h \
-	context.c cache.c fetch.c obj.c crawler.c alloc.c plugin.c
+LIBS = $(top_builddir)/libcrawl/libcrawl.la
 
-libcrawl_la_LDFLAGS = -avoid-version
+moduledir = $(libdir)/anansi
 
-libcrawl_la_LIBADD = \
-	caches/libcaches.la \
-	$(top_builddir)/libsupport/libsupport.la \
-	$(LIBJANSSON_LOCAL_LIBS) $(LIBJANSSON_LIBS) \
-	$(LIBURI_LOCAL_LIBS) $(LIBURI_LIBS) \
-	$(LIBCURL_LOCAL_LIBS) $(LIBCURL_LIBS) \
-	$(OPENSSL_LOCAL_LIBS) $(OPENSSL_LIBS)
+module_LTLIBRARIES = logger.la
+
+logger_la_SOURCES = logger.c
+logger_la_LDFLAGS = -no-undefined -module -avoid-version

--- a/crawler/plug-ins/logger/logger.c
+++ b/crawler/plug-ins/logger/logger.c
@@ -1,0 +1,59 @@
+/* Anansi plug-in
+ *
+ * Author: Christophe Gueret <christophe.gueret@bbc.co.uk>
+ *
+ * Copyright (c) 2016 BBC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libcrawl.h"
+#include "libsupport.h"
+
+#define CRAWL_PLUGIN_NAME "logger"
+
+static int log_uri(CRAWL *restrict context, const char *restrict uristr, void *data);
+
+/* Anansi plug-in entry-point */
+int
+anansi_entry(CRAWL *context, CRAWLPLUGINENTRYTYPE type, void *handle)
+{
+	(void) handle;
+
+	switch(type)
+	{
+	case CRAWL_ATTACHED:
+		log_printf(LOG_DEBUG, CRAWL_PLUGIN_NAME " plug-in: initialising\n");
+		// Register to signal
+		crawl_plugin_attach_signal(context, QUEUE_URI_ADDED, "logger", log_uri, NULL);
+		break;
+	case CRAWL_DETACHED:
+		// De-register
+		break;
+	}
+	return 0;
+}
+
+static int log_uri(CRAWL *restrict context, const char *restrict uristr, void *data)
+{
+	log_printf(LOG_INFO, CRAWL_PLUGIN_NAME " plug-in: Added %s to the queue !\n", uristr);
+	return 0;
+}

--- a/crawler/queue.c
+++ b/crawler/queue.c
@@ -25,6 +25,7 @@
 
 #include "p_libcrawld.h"
 
+
 /* Implement a libcrawl queue handler which interfaces with crawld queue
  * modules.
  */
@@ -57,6 +58,7 @@ queue_init(void)
 		log_printf(LOG_CRIT, MSG_C_CRAWL_QUEUEUNKNOWN ": '%s'\n", name);
 		return -1;
 	}
+
 	return 0;
 }
 
@@ -81,6 +83,10 @@ queue_init_context(CONTEXT *context)
 		return -1;
 	}
 	crawl_set_next(crawl, queue_handler_);
+
+	// Load all the plugins
+	config_get_all("queue", "plugin", crawl_plugin_load_cb, crawl);
+
 	return 0;
 }
 
@@ -88,33 +94,13 @@ queue_init_context(CONTEXT *context)
 int
 queue_add_uristr(CRAWL *crawl, const char *uristr)
 {
-	CONTEXT *data;
 	URI *uri;
-	CRAWLSTATE state;
 	int r;
 
-	data = crawl_userdata(crawl);
 	uri = uri_create_str(uristr, NULL);
-	if(!uri)
-	{
-		log_printf(LOG_ERR, MSG_E_CRAWL_URIPARSE " <%s>\n", uristr);
-		return -1;
-	}
-	state = policy_uri_(crawl, uri, uristr, (void *) data);
-	if(state == COS_ACCEPTED)
-	{
-		log_printf(LOG_DEBUG, "Adding URI <%s> to crawler queue\n", uristr);
-		r = data->queue->api->add(data->queue, uri, uristr);
-	}
-	else if(state == COS_ERR)
-	{
-		r = -1;
-	}
-	else
-	{
-		r = 0;
-	}
+	r = queue_add_uri(crawl, uri);
 	uri_destroy(uri);
+
 	return r;
 }
 
@@ -139,6 +125,10 @@ queue_add_uri(CRAWL *crawl, URI *uri)
 	{
 		log_printf(LOG_DEBUG, "Adding URI <%s> to crawler queue\n", uristr);
 		r = data->queue->api->add(data->queue, uri, uristr);
+
+		// Send a signal to all the plugins watching on this event
+		crawl_plugin_signal(crawl, QUEUE_URI_ADDED, uristr);
+
 	}
 	else if(state == COS_ERR)
 	{
@@ -208,3 +198,5 @@ queue_handler_(CRAWL *crawl, URI **next, CRAWLSTATE *state, void *userdata)
 	}
 	return data->queue->api->next(data->queue, next, state);
 }
+
+

--- a/libcrawl/context.c
+++ b/libcrawl/context.c
@@ -38,6 +38,11 @@ crawl_create(void)
 		crawl_destroy(p);
 		return NULL;
 	}
+
+	// Init the callbacks
+	p->callbacks = NULL;
+	p->cbcount = 0;
+
 	return p;
 }
 
@@ -59,6 +64,7 @@ crawl_destroy(CRAWL *p)
 		crawl_free(p, p->cachetmp);
 		crawl_free(p, p->accept);
 		crawl_free(p, p->ua);
+		crawl_free(p, p->callbacks);
 		crawl_free(NULL, p);
 	}
 }

--- a/libcrawl/libcrawl.h
+++ b/libcrawl/libcrawl.h
@@ -50,6 +50,19 @@ typedef enum
 	COS_SKIPPED
 } CRAWLSTATE;
 
+/* Plug-in entry-point: invoked when a plug-in is loaded or un-loaded */
+typedef enum
+{
+	CRAWL_ATTACHED,
+	CRAWL_DETACHED
+} CRAWLPLUGINENTRYTYPE;
+
+
+typedef enum
+{
+	QUEUE_URI_ADDED = 1
+} CRAWLSIGNALNAME;
+
 /* A crawl context.
  *
  * Note that while libcrawl is thread-safe, a single crawl context cannot be
@@ -58,6 +71,19 @@ typedef enum
  * libcrawl methods.
  */
 typedef struct crawl_struct CRAWL;
+
+typedef int (*CRAWLPLUGINENTRYFN)(CRAWL *context, CRAWLPLUGINENTRYTYPE type, void *handle);
+
+/* This function must be provided by plug-ins themselves - it is not an API
+ * which can be invoked as part of libcrawl
+ */
+int crawl_plugin_entry(CRAWL *restrict context, CRAWLPLUGINENTRYTYPE type, void *restrict handle);
+
+/* Callback called when a URI is added to the queue or removed from it
+ */
+typedef int (*CRAWLSIGNALCBFN)(CRAWL *restrict context, const char *restrict uristr, void *userdata);
+
+
 
 /* A cache implementation.
  *
@@ -259,5 +285,10 @@ void *crawl_alloc(CRAWL *restrict crawl, size_t nbytes);
 char *crawl_strdup(CRAWL *restrict crawl, const char *src);
 void *crawl_realloc(CRAWL *restrict crawl, void *restrict ptr, size_t nbytes);
 void crawl_free(CRAWL *restrict crawl, void *restrict ptr);
+
+/* Plug-ins */
+int crawl_plugin_load_cb(const char *plugin, const char *pathname, void *context);
+int crawl_plugin_attach_signal(CRAWL *crawl, CRAWLSIGNALNAME signal, const char *description, CRAWLSIGNALCBFN fn, void *userdata);
+int crawl_plugin_signal(CRAWL *crawl, CRAWLSIGNALNAME signal, const char *uristr);
 
 #endif /*!LIBCRAWL_H_*/

--- a/libcrawl/p_libcrawl.h
+++ b/libcrawl/p_libcrawl.h
@@ -32,6 +32,7 @@
 # include <fcntl.h>
 # include <unistd.h>
 # include <syslog.h>
+# include <dlfcn.h>
 
 # include <curl/curl.h>
 
@@ -100,6 +101,14 @@
 # define MSG_E_S3_TMPFILE               "%%ANANSI-E-4100: S3: failed to create temporary file"
 # define MSG_E_S3_HTTP                  "%%ANANSI-E-4101: S3: failed to retrieve object from cache"
 
+struct plugin_callback_struct
+{
+	CRAWLSIGNALNAME signal;
+	CRAWLSIGNALCBFN fn;
+	void *data;
+	char *desc;
+};
+
 struct crawl_struct
 {
 	void *userdata;
@@ -122,6 +131,8 @@ struct crawl_struct
 	crawl_unchanged_cb unchanged;
 	crawl_prefetch_cb prefetch;
 	void (*logger)(int priority, const char *format, va_list ap);
+	struct plugin_callback_struct *callbacks;
+	size_t cbcount;
 };
 
 struct crawl_object_struct

--- a/libcrawl/plugin.c
+++ b/libcrawl/plugin.c
@@ -1,0 +1,134 @@
+/* Crawl: Plug-in handling
+ *
+ * Author: Mo McRoberts <mo.mcroberts@bbc.co.uk>
+ *
+ * Copyright (c) 2014-2016 BBC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "p_libcrawl.h"
+# include "libsupport.h"
+
+#define PLUGINDIR                       LIBDIR "/" PACKAGE_TARNAME "/"
+
+
+/* Load a plug-in and invoke its initialiser callback */
+int
+crawl_plugin_load_cb(const char *plugin, const char *pathname, void *context)
+{
+	void *handle;
+	CRAWLPLUGINENTRYFN entry;
+	char *fnbuf;
+	size_t len;
+	int r;
+
+	log_printf(LOG_DEBUG, "loading plug-in %s\n", pathname);
+	if(strchr(pathname, '/'))
+	{
+		fnbuf = NULL;
+	}
+	else
+	{
+		len = strlen(pathname) + strlen(PLUGINDIR) + 1;
+		fnbuf = (char *) malloc(len);
+		if(!fnbuf)
+		{
+			log_printf(LOG_CRIT, "failed to allocate %u bytes\n", (unsigned) len);
+			return -1;
+		}
+		strcpy(fnbuf, PLUGINDIR);
+		strcat(fnbuf, pathname);
+		pathname = fnbuf;
+	}
+	handle = dlopen(pathname, RTLD_NOW);
+	if(!handle)
+	{
+		log_printf(LOG_ERR, "failed to load %s: %s\n", pathname, dlerror());
+		free(fnbuf);
+		return -1;
+	}
+	entry = (CRAWLPLUGINENTRYFN) dlsym(handle, "anansi_entry");
+	r = entry(context, CRAWL_ATTACHED, handle);
+	if(r)
+	{
+		log_printf(LOG_ERR, "initialisation of plug-in %s failed\n", pathname);
+		return -1;
+	}
+	log_printf(LOG_DEBUG, "loaded plug-in %s\n", pathname);
+	free(fnbuf);
+	return 0;
+}
+
+/* Public: Register a signal handler */
+int
+crawl_plugin_attach_signal(CRAWL *context, CRAWLSIGNALNAME signal, const char *description, CRAWLSIGNALCBFN fn, void *userdata)
+{
+	// Create the structure
+	struct plugin_callback_struct p;
+
+	// Copy the description
+	p.desc = strdup(description);
+	if(!p.desc)
+	{
+		log_printf(LOG_ERR, "failed to allocate memory\n");
+		return -1;
+	}
+
+	// Set the function, the signal name and the user data
+	p.fn = fn;
+	p.signal = signal;
+	p.data = userdata;
+
+	// Adjust the size of the array of callbacks
+	struct plugin_callback_struct *callbacks;
+	callbacks = (struct plugin_callback_struct *) realloc(context->callbacks, sizeof(struct plugin_callback_struct) * (context->cbcount + 1));
+	if(!callbacks)
+	{
+		log_printf(LOG_ERR, "failed to allocate memory\n");
+		return NULL;
+	}
+	context->callbacks = callbacks;
+	context->callbacks[context->cbcount] = p;
+	context->cbcount++;
+
+	log_printf(LOG_INFO, "attached signal %d to %p from callback '%s'\n", p.signal, p.fn, p.desc);
+
+	return 0;
+}
+
+int crawl_plugin_signal(CRAWL *crawl, CRAWLSIGNALNAME signal, const char *uristr)
+{
+	struct plugin_callback_struct *p;
+
+	log_printf(LOG_DEBUG, "Sending signal %d to %d callbacks\n", signal, crawl->cbcount);
+
+	for (size_t i=0; i < crawl->cbcount; i++)
+	{
+		p = &(crawl->callbacks[i]);
+		log_printf(LOG_INFO, "Checking %d -> %d\n", i, p->signal);
+		if (p->signal == signal)
+		{
+			log_printf(LOG_INFO, "Call back %d matching signal at %p\n", i, p->fn);
+			p->fn(crawl, uristr, p->data);
+		}
+	}
+
+	return 0;
+}
+
+

--- a/libcrawl/plugin.c
+++ b/libcrawl/plugin.c
@@ -63,7 +63,10 @@ crawl_plugin_load_cb(const char *plugin, const char *pathname, void *context)
 		return -1;
 	}
 	entry = (CRAWLPLUGINENTRYFN) dlsym(handle, "anansi_entry");
-	r = entry(context, CRAWL_ATTACHED, handle);
+	if (entry)
+	{
+		r = entry(context, CRAWL_ATTACHED, handle);
+	}
 	if(r)
 	{
 		log_printf(LOG_ERR, "initialisation of plug-in %s failed\n", pathname);


### PR DESCRIPTION
Can you have a look and see if that's going in the right direction ? There is no code to de-register and cleanup the plugins yet.

The code is used adjusting the config of the crawler that way:
```
[queue]
name=db
uri=pgsql://postgres:postgres@postgres/anansi
debug-queries=no
debug-errors=yes
;; Plugins for the queue
plugin=logger.so
```